### PR TITLE
fixed error in accordion linking

### DIFF
--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -88,14 +88,14 @@
         </div>
 
         <div class="card">
-            <div class="card-header" role="tab" id="headingThree">
+            <div class="card-header" role="tab" id="headingFour">
             <h4 class="mb-0">
-                <a class="collapsed" data-toggle="collapse" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+                <a class="collapsed" data-toggle="collapse" href="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
                 Coding da Vinci
                 </a>
             </h4>
             </div>
-            <div id="collapseThree" class="collapse" role="tabpanel" aria-labelledby="headingThree" data-parent="#accordion">
+            <div id="collapseFour" class="collapse" role="tabpanel" aria-labelledby="headingFour" data-parent="#accordion">
             <div class="card-body">
                 <p>Coding da Vinci ist der erste deutsche Hackathon für offene Kulturdaten. Seit 2014 vernetzt Coding da Vinci technikaffine und kulturbegeisterte Communities mit deutschen Kulturinstitutionen, um das kreative Potential in unserem digitalen Kulturerbe weiter zu entfalten.</p>
                 <p>Während ein klassischer Hackathon den Teilnehmern nur wenig Zeit gibt, Softwareanwendungen zu entwickeln – in der Regel ein Wochenende – erstreckt sich Coding da Vinci über eine Zeitspanne von sechs bis zehn Wochen. Dieser erweiterte Zeitrahmen schafft den dringend benötigten Raum, in dem sich die oft getrennten Welten kreativer Technologieentwicklung und institutioneller Kulturbewahrung treffen können, um voneinander zu lernen und miteinander aktiv zu werden.


### PR DESCRIPTION
the accordion section for Coding da Vinci had the id "collapseThree" which was the same as for "Das Team", causing that section to open when the heading was clicked. Renamed all references to "collapseFour", which should fix the issue now (I hope I didn't overlook anything)